### PR TITLE
Add RPS counter to help guage app performance

### DIFF
--- a/backend/deja_brew/__init__.py
+++ b/backend/deja_brew/__init__.py
@@ -1,3 +1,5 @@
+import datetime
+
 from flask import Flask
 from oauthlib.oauth2 import WebApplicationClient
 
@@ -8,8 +10,8 @@ from deja_brew.config import Config, LocalConfig
 from deja_brew.frontend import frontend_bp
 from deja_brew.frontend.asset_manifest_supplier import create_asset_manifest_supplier
 from deja_brew.healthcheck import healthz_bp
+from deja_brew.healthcheck.rps_counter import RpsCounter
 from deja_brew.repository import db, Base
-
 
 def create_app(config: Config = None):
     if config is None:
@@ -30,5 +32,8 @@ def create_app(config: Config = None):
     app.oauth_client = WebApplicationClient(app.config['GOOGLE_CLIENT_ID'])
     app.manifest_supplier = create_asset_manifest_supplier(
         app.config['ASSET_MANIFEST_SUPPLIER_IMPL'])
+
+    app.rps_counter = RpsCounter()
+    app.before_request(app.rps_counter.track_request)
 
     return app

--- a/backend/deja_brew/__init__.py
+++ b/backend/deja_brew/__init__.py
@@ -1,5 +1,3 @@
-import datetime
-
 from flask import Flask
 from oauthlib.oauth2 import WebApplicationClient
 
@@ -12,6 +10,7 @@ from deja_brew.frontend.asset_manifest_supplier import create_asset_manifest_sup
 from deja_brew.healthcheck import healthz_bp
 from deja_brew.healthcheck.rps_counter import RpsCounter
 from deja_brew.repository import db, Base
+
 
 def create_app(config: Config = None):
     if config is None:

--- a/backend/deja_brew/healthcheck/__init__.py
+++ b/backend/deja_brew/healthcheck/__init__.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, jsonify
+from flask import Blueprint, jsonify, current_app
 
 from deja_brew.repository import db
 from .version import get_version
@@ -32,4 +32,14 @@ def index():
 def version():
     return jsonify(
         version=get_version(),
+    )
+
+
+@healthz_bp.route('/rps')
+def rps():
+    (avg_1, avg_5, avg_60) = current_app.rps_counter.get_stats()
+    return jsonify(
+        avg1=avg_1,
+        avg5=avg_5,
+        avg60=avg_60,
     )

--- a/backend/deja_brew/healthcheck/rps_counter.py
+++ b/backend/deja_brew/healthcheck/rps_counter.py
@@ -1,0 +1,25 @@
+import datetime
+
+
+class RpsCounter:
+    def __init__(self):
+        self._req_counts = [0 for _ in range(60)]
+        self._curr_ptr = None
+
+    def track_request(self):
+        now = datetime.datetime.now()
+        old_ptr = self._curr_ptr
+        self._curr_ptr = now.minute
+        if old_ptr is not None and self._curr_ptr != old_ptr:
+            for x in range(old_ptr + 1, self._curr_ptr + 1):
+                print(x)
+                self._req_counts[x] = self._req_counts[x - 1]
+
+        self._req_counts[self._curr_ptr] += 1
+
+    def get_stats(self):
+        return (
+            (self._req_counts[self._curr_ptr] - self._req_counts[self._curr_ptr - 1]) / 60,
+            (self._req_counts[self._curr_ptr] - self._req_counts[self._curr_ptr - 5]) / (60 * 5),
+            (self._req_counts[self._curr_ptr] - self._req_counts[self._curr_ptr - 15]) / (60 * 60),
+        )


### PR DESCRIPTION
Since we are using a polling technique it would be good to understand the load on the service. These stats will compliment those which are already available within AWS for the ELB.


![image](https://user-images.githubusercontent.com/1289759/76138110-68eed700-6098-11ea-96d9-61eb294f1471.png)
